### PR TITLE
Ignore /compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ fc-scan/fc-scan
 fc-scan/fc-scan.1
 src/fontconfig.def
 test-driver
+/compile


### PR DESCRIPTION
Building Servo on linux creates an auto-generated, untracked `compile` file that makes the fontconfig submodule appear as "dirty" when running "git status" on the Servo repository.

Add this file to fontconfig’s `.gitignore`.
