### PR TITLE
Set sysconfdir and localstatedir on linux.

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -15,7 +15,10 @@ else
 CC ?= gcc
 AR ?= ar
 
-CONFIGURE_FLAGS ?=
+CONFIGURE_FLAGS := \
+    --sysconfdir=/etc \
+    --localstatedir=/var \
+    $(NULL)
 
 endif
 


### PR DESCRIPTION
The old build system used this, but I forgot to include it here.
